### PR TITLE
Fix for TGIANN Inventory regarding missing fields.

### DIFF
--- a/formatting/formatItem/shared.lua
+++ b/formatting/formatItem/shared.lua
@@ -9,14 +9,27 @@
 ---@param item table
 ---@return Item
 function Formatting.formatItem(item)
-    local formatted = {
-        name = item.name or item.item,
-        label = item.label,
-        amount = item.amount or item.count or item.value or 1,
-        weight = item.weight,
-        metadata = item.metadata or item.info,
-        slot = item.slot
-    }
+    local formatted = {}
+    if Inventory == "TGIANN" then
+        formatted = {
+            name = item.name or item.item,
+            label = item.label,
+            amount = item.amount or item.count or item.value or 1,
+            weight = item.weight,
+            info = item.info or {},
+            metadata = item.metadata or item.info or {},
+            slot = item.slot
+        }
+    else
+        formatted = {
+            name = item.name or item.item,
+            label = item.label,
+            amount = item.amount or item.count or item.value or 1,
+            weight = item.weight,
+            metadata = item.metadata or item.info,
+            slot = item.slot
+        }
+    end
 
     -- TGIANN stores both metadata & info, we need to use info here for the correct data
     -- Also check if .info exists, because if it is an internal call we may have already translated it

--- a/internals/items/server.lua
+++ b/internals/items/server.lua
@@ -16,7 +16,12 @@ RegisterNetEvent("zyke_lib:MissingMetadata", function(slot)
     local item = Functions.getInventorySlot(source, slot)
     if (not item) then return end
 
-    local newMetadata = item.metadata or {}
+    local newMetadata = {}
+    if Inventory == "TGIANN" then
+        newMetadata = item.info or {}
+    else
+        newMetadata = item.metadata or {}
+    end
     local added = 0
 
     local desiredMetadata = ensuredMetadata[item.name]
@@ -27,7 +32,14 @@ RegisterNetEvent("zyke_lib:MissingMetadata", function(slot)
 
     ---@diagnostic disable-next-line: param-type-mismatch
     for metaKey, metaValue in pairs(desiredMetadata) do
-        local metadata = item.metadata[metaKey]
+        local metadata = nil
+
+        --Extra check for people using TGIANN Inventory (Consumables Hotfix, still does contain referencing errors, more indepth code modification will be needed)
+        if Inventory == "TGIANN" then
+            metadata = item.info[metaKey]
+        else
+            metadata = item.metadata[metaKey]
+        end
 
         local newVal
         if (metadata == nil) then


### PR DESCRIPTION
Fixed error caused by "Reference to Invalid field ('metadata')" issue while using Zyke_Consumables with TGIANN Inventory due to truncation of the "info" table while reformatting Items Data.