### PR TITLE
Latest Tgiann Inventory support for Zyke-Lib, fix for handling Metadata.

### DIFF
--- a/formatting/formatItem/shared.lua
+++ b/formatting/formatItem/shared.lua
@@ -9,14 +9,27 @@
 ---@param item table
 ---@return Item
 function Formatting.formatItem(item)
-    local formatted = {
-        name = item.name or item.item,
-        label = item.label,
-        amount = item.amount or item.count or item.value or 1,
-        weight = item.weight,
-        metadata = item.metadata or item.info,
-        slot = item.slot
-    }
+    local formatted = {}
+    if Inventory == "TGIANN" then
+        formatted = {
+            name = item.name or item.item,
+            label = item.label,
+            amount = item.amount or item.count or item.value or 1,
+            weight = item.weight,
+            info = item.info or {},
+            metadata = item.metadata or item.info or {},
+            slot = item.slot
+        }
+    else
+        formatted = {
+            name = item.name or item.item,
+            label = item.label,
+            amount = item.amount or item.count or item.value or 1,
+            weight = item.weight,
+            metadata = item.metadata or item.info,
+            slot = item.slot
+        }
+    end
 
     -- TGIANN stores both metadata & info, we need to use info here for the correct data
     -- Also check if .info exists, because if it is an internal call we may have already translated it

--- a/internals/items/client.lua
+++ b/internals/items/client.lua
@@ -43,15 +43,28 @@ RegisterNetEvent("zyke_lib:InventoryUpdated", function(changes)
         if (modifySlots and not modifiedSlots[tostring(item.slot)]) then goto continue end
 
         local missingMetadata = false
-        if (item.metadata) then
-            for metaKey in pairs(ensuredMetadata[name]) do
-                if (item.metadata[metaKey] == nil) then
-                    missingMetadata = true
-                    break
+        if Inventory == "TGIANN" then
+            if (item.info) then
+                for metaKey in pairs(ensuredMetadata[name]) do
+                    if (item.info[metaKey] == nil) then
+                        missingMetadata = true
+                        break
+                    end
                 end
+            else
+                missingMetadata = true
             end
         else
-            missingMetadata = true
+            if (item.metadata) then
+                for metaKey in pairs(ensuredMetadata[name]) do
+                    if (item.metadata[metaKey] == nil) then
+                        missingMetadata = true
+                        break
+                    end
+                end
+            else
+                missingMetadata = true
+            end
         end
 
         if (missingMetadata) then

--- a/internals/items/server.lua
+++ b/internals/items/server.lua
@@ -16,7 +16,12 @@ RegisterNetEvent("zyke_lib:MissingMetadata", function(slot)
     local item = Functions.getInventorySlot(source, slot)
     if (not item) then return end
 
-    local newMetadata = item.metadata or {}
+    local newMetadata = {}
+    if Inventory == "TGIANN" then
+        newMetadata = item.info or {}
+    else
+        newMetadata = item.metadata or {}
+    end
     local added = 0
 
     local desiredMetadata = ensuredMetadata[item.name]
@@ -27,7 +32,14 @@ RegisterNetEvent("zyke_lib:MissingMetadata", function(slot)
 
     ---@diagnostic disable-next-line: param-type-mismatch
     for metaKey, metaValue in pairs(desiredMetadata) do
-        local metadata = item.metadata[metaKey]
+        local metadata = nil
+
+        --Extra check for people using TGIANN Inventory (Consumables Hotfix, still does contain referencing errors, more indepth code modification will be needed)
+        if Inventory == "TGIANN" then
+            metadata = item.info[metaKey]
+        else
+            metadata = item.metadata[metaKey]
+        end
 
         local newVal
         if (metadata == nil) then


### PR DESCRIPTION
Data storage for metadata of Player Items is shifted to "info" table for Tgiann-Inventory to fix the issue of referencing unknown field 'metadata' while using Consumables from Inventory.